### PR TITLE
fixed case where checkurl returns a single tuple but CHECKURL-MULTI rather than CHECKURL-CONTENTS should be used because the tuple contains a url

### DIFF
--- a/annexremote/annexremote.py
+++ b/annexremote/annexremote.py
@@ -261,7 +261,7 @@ class Protocol:
         elif reply is True:
             return "CHECKURL-CONTENTS UNKNOWN"
         
-        if len(reply)==1:
+        if len(reply)==1 and 'url' not in reply[0]:
             entry = reply[0]
             if 'size' not in entry or entry['size'] is None:
                 entry['size'] = "UNKNOWN"


### PR DESCRIPTION
fixed case where checkurl returns a single tuple but CHECKURL-MULTI rather than CHECKURL-CONTENTS should be used because the tuple contains a url .  See also https://git-annex.branchable.com/todo/addurl_improvements/