### PR TITLE
MAINT: Drop Python <3.6 support, increase stated support to 3.9

### DIFF
--- a/annexremote/annexremote.py
+++ b/annexremote/annexremote.py
@@ -9,23 +9,11 @@
 # warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #
 
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from builtins import int
-from builtins import str
-from future import standard_library
-standard_library.install_aliases()
-from future.utils import with_metaclass
-from builtins import object
-
 import logging
 
 from abc import ABCMeta, abstractmethod
 
 import sys, traceback
-import string
 
 
 # Exceptions
@@ -74,7 +62,7 @@ class AnnexLoggingHandler(logging.StreamHandler):
         for line in log_entry.splitlines():
             self.annex.debug(line)
 
-class SpecialRemote(with_metaclass(ABCMeta, object)):
+class SpecialRemote(metaclass=ABCMeta):
     """
     Metaclass for non-export remotes.
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,6 @@ setup(
 
     install_requires=[],
     extras_require={
-        'test': ['coverage', 'nose', 'mock'],
+        'test': ['coverage', 'nose'],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -43,15 +43,15 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
 
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     keywords='git-annex remote',
     packages=['annexremote'],
 
-    install_requires=['future'],
+    install_requires=[],
     extras_require={
         'test': ['coverage', 'nose', 'mock'],
     },

--- a/tests/test_AnnexRemoteSetup.py
+++ b/tests/test_AnnexRemoteSetup.py
@@ -1,17 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import io
 import unittest
 
 import annexremote
-
-import utils
 
 
 class SetupTestCase(unittest.TestCase):

--- a/tests/test_GitAnnexRequestMessages.py
+++ b/tests/test_GitAnnexRequestMessages.py
@@ -1,13 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import io
-from unittest import skip
 import logging
 
 import utils

--- a/tests/test_SpecialRemoteMessages.py
+++ b/tests/test_SpecialRemoteMessages.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import io
 import utils
 ProtocolError = utils.annexremote.ProtocolError

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,15 +1,5 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import super
-from future import standard_library
-standard_library.install_aliases()
 import unittest
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 import io
 
 import os, sys


### PR DESCRIPTION
Python 3.5 and below are all end-of-life. On 3.9 installations of dependencies, I'm getting deprecation warnings about `import imp` which is done in `future`, which is also EOL.

This PR does the following:

* Drops `future` from dependencies
* Removes all imports from `future`, `builtins` and `__future__`
* Updated metaclass call to use Py3 syntax
* Removed some additional unneeded 
* Removed mock from testing dependencies

Closes #18.