### PR TITLE
fix: update assertion error text

### DIFF
--- a/tests/test_GitAnnexRequestMessages.py
+++ b/tests/test_GitAnnexRequestMessages.py
@@ -302,7 +302,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
     def TestExport_MissingName(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("EXPORT"))
-        self.assertEqual(utils.last_buffer_line(self.output), "ERROR do_EXPORT() missing 1 required positional argument: 'name'")
+        self.assertEqual(utils.last_buffer_line(self.output), "ERROR Protocol.do_EXPORT() missing 1 required positional argument: 'name'")
 
     def TestExport_SpaceInName(self):
         # testing this only with TRANSFEREXPORT
@@ -420,7 +420,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
     def TestRemoveexportdirectory_MissingDirectory(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("REMOVEEXPORTDIRECTORY"))
-        self.assertEqual(utils.last_buffer_line(self.output), "ERROR do_REMOVEEXPORTDIRECTORY() missing 1 required positional argument: 'name'")
+        self.assertEqual(utils.last_buffer_line(self.output), "ERROR Protocol.do_REMOVEEXPORTDIRECTORY() missing 1 required positional argument: 'name'")
 
     def TestRemoveexportdirectory_SpaceInFilename(self):
         self.annex.Listen(io.StringIO("REMOVEEXPORTDIRECTORY Directory with spaces"))


### PR DESCRIPTION
While packaging annexremote for Fedora, we see these two failures:

```
=================================== FAILURES ===================================
________ TestGitAnnexRequestMessagesExporttree.test_Export_MissingName _________

self = <test_GitAnnexRequestMessages.TestGitAnnexRequestMessagesExporttree testMethod=test_Export_MissingName>

    def test_Export_MissingName(self):
        with self.assertRaises(SystemExit):
            self.annex.Listen(io.StringIO("EXPORT"))
>       self.assertEqual(utils.last_buffer_line(self.output), "ERROR do_EXPORT() missing 1 required positional argument: 'name'")
E       AssertionError: "ERROR Protocol.do_EXPORT() missing 1 required positional argument: 'name'" != "ERROR do_EXPORT() missing 1 required positional argument: 'name'"
E       - ERROR Protocol.do_EXPORT() missing 1 required positional argument: 'name'
E       ?       ---------
E       + ERROR do_EXPORT() missing 1 required positional argument: 'name'

tests/test_GitAnnexRequestMessages.py:311: AssertionError
_ TestGitAnnexRequestMessagesExporttree.test_Removeexportdirectory_MissingDirectory _

self = <test_GitAnnexRequestMessages.TestGitAnnexRequestMessagesExporttree testMethod=test_Removeexportdirectory_MissingDirectory>

    def test_Removeexportdirectory_MissingDirectory(self):
        with self.assertRaises(SystemExit):
            self.annex.Listen(io.StringIO("REMOVEEXPORTDIRECTORY"))
>       self.assertEqual(utils.last_buffer_line(self.output), "ERROR do_REMOVEEXPORTDIRECTORY() missing 1 required positional argument: 'name'")
E       AssertionError: "ERROR Protocol.do_REMOVEEXPORTDIRECTORY() missi[37 chars]ame'" != "ERROR do_REMOVEEXPORTDIRECTORY() missing 1 requ[28 chars]ame'"
E       - ERROR Protocol.do_REMOVEEXPORTDIRECTORY() missing 1 required positional argument: 'name'
E       ?       ---------
E       + ERROR do_REMOVEEXPORTDIRECTORY() missing 1 required positional argument: 'name'

tests/test_GitAnnexRequestMessages.py:429: AssertionError
=============================== warnings summary ===============================
../../../../usr/lib/python3.10/site-packages/future/standard_library/__init__.py:65
  /usr/lib/python3.10/site-packages/future/standard_library/__init__.py:65: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=========================== short test summary info ============================
FAILED tests/test_GitAnnexRequestMessages.py::TestGitAnnexRequestMessagesExporttree::test_Export_MissingName
FAILED tests/test_GitAnnexRequestMessages.py::TestGitAnnexRequestMessagesExporttree::test_Removeexportdirectory_MissingDirectory
=================== 2 failed, 131 passed, 1 warning in 0.26s ===================

```

This patch fixes them both.