### PR TITLE
Add 3.10 and 3.11 into the mix of supported Pythons

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 nose coverage
+        python -m pip install flake8 nose3 coverage
         pip install .
     - name: Lint with flake8
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ classifiers = [
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
 ]
 keywords = ["git-annex", "remote"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,6 @@ enabled = true
 [tool.setuptools_scm]
 write_to = "annexremote/_version.py"
 fallback_version = "0.0.0"
+
+[tool.setuptools]
+packages = ["annexremote"]

--- a/tests/test_GitAnnexRequestMessages.py
+++ b/tests/test_GitAnnexRequestMessages.py
@@ -382,9 +382,9 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
     def TestExport_MissingName(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("EXPORT"))
-        self.assertEqual(
+        self.assertRegex(
             utils.last_buffer_line(self.output),
-            "ERROR do_EXPORT() missing 1 required positional argument: 'name'",
+            "ERROR (Protocol\.|)do_EXPORT\(\) missing 1 required positional argument: 'name'",
         )
 
     def TestExport_SpaceInName(self):
@@ -560,9 +560,9 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
     def TestRemoveexportdirectory_MissingDirectory(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("REMOVEEXPORTDIRECTORY"))
-        self.assertEqual(
+        self.assertRegex(
             utils.last_buffer_line(self.output),
-            "ERROR do_REMOVEEXPORTDIRECTORY() missing 1 required positional argument: 'name'",
+            "ERROR (Protocol\.|)do_REMOVEEXPORTDIRECTORY\(\) missing 1 required positional argument: 'name'",
         )
 
     def TestRemoveexportdirectory_SpaceInFilename(self):

--- a/tests/test_SpecialRemoteMessages.py
+++ b/tests/test_SpecialRemoteMessages.py
@@ -460,7 +460,6 @@ class TestSpecialRemoteMessages_Extensions(utils.GitAnnexTestCase):
         annex_reply=None,
         function_result=None,
     ):
-
         self.annex.input = io.StringIO(annex_reply)
         result = function_to_call(*function_parameters)
         self.assertEqual(result, function_result)


### PR DESCRIPTION
Builds for 3.11 were failing on https://github.com/conda-forge/annexremote-feedstock/pull/38 (logs are gone now), so might need some fixing.
Attn @notestaff as well who maintains recipe for conda-forge

Whenever done with it -- better be released, currently is at v1.6.0-31-gcba9dc5 in master.

Closes #65 
Closes #33 