### PR TITLE
Specify "packages" for pyproject.toml to make installable in venvs (tried on 3.10, 3.11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,6 @@ enabled = true
 [tool.setuptools_scm]
 write_to = "annexremote/_version.py"
 fallback_version = "0.0.0"
+
+[tool.setuptools]
+packages = ["annexremote"]


### PR DESCRIPTION
Closes #65