### PR TITLE
Address consecutive EXPORT

### DIFF
--- a/annexremote/annexremote.py
+++ b/annexremote/annexremote.py
@@ -388,6 +388,10 @@ class ExportRemote(SpecialRemote):
         Note that the user is not required to provided all the settings listed here.
     """
 
+    def __init__(self, annex, force_version1=False):
+        self.force_version1 = force_version1
+        super().__init__(annex)
+
     def exportsupported(self):
         return True
 
@@ -550,7 +554,7 @@ class Protocol(object):
 
     @property
     def version(self):
-        if self.remote.exportsupported():
+        if self.remote.exportsupported() and not self.remote.force_version1:
             return "VERSION 2"
         else:
             return "VERSION 1"

--- a/annexremote/annexremote.py
+++ b/annexremote/annexremote.py
@@ -734,6 +734,8 @@ class Protocol(object):
             return "EXPORTSUPPORTED-FAILURE"
 
     def do_EXPORT(self, name):
+        if self.exporting:
+            raise UnexpectedMessage("Unexpected EXPORT")
         self.exporting = name
 
     def do_TRANSFEREXPORT(self, param):

--- a/annexremote/annexremote.py
+++ b/annexremote/annexremote.py
@@ -545,9 +545,15 @@ class Protocol(object):
 
     def __init__(self, remote):
         self.remote = remote
-        self.version = "VERSION 1"
         self.exporting = False
         self.extensions = list()
+
+    @property
+    def version(self):
+        if self.remote.exportsupported():
+            return "VERSION 2"
+        else:
+            return "VERSION 1"
 
     def command(self, line):
         line = line.strip()

--- a/examples/git-annex-remote-directory
+++ b/examples/git-annex-remote-directory
@@ -133,7 +133,6 @@ class DirectoryRemote(ExportRemote):
 
 
 def main():
-
     # Redirect output to stderr to avoid messing up the protocol
     output = sys.stdout
     sys.stdout = sys.stderr

--- a/tests/test_GitAnnexRequestMessages.py
+++ b/tests/test_GitAnnexRequestMessages.py
@@ -387,6 +387,11 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             r"ERROR (Protocol\.|)do_EXPORT\(\) missing 1 required positional argument: 'name'",
         )
 
+    def test_Export_DoubleExport(self):
+        with self.assertRaises(SystemExit):
+            self.annex.Listen(io.StringIO("EXPORT Name1\nEXPORT Name2"))
+        self.assertEqual(utils.last_buffer_line(self.output), "ERROR Unexpected EXPORT")
+
     def test_Export_SpaceInName(self):
         # testing this only with TRANSFEREXPORT
         self.annex.Listen(

--- a/tests/test_GitAnnexRequestMessages.py
+++ b/tests/test_GitAnnexRequestMessages.py
@@ -10,7 +10,7 @@ ProtocolError = utils.annexremote.ProtocolError
 UnsupportedReqeust = utils.annexremote.UnsupportedRequest
 
 
-class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
+class TestGitAnnexRequestMessages(utils.ExportTestCase):
     def test_InitremoteSuccess(self):
         self.annex.Listen(io.StringIO("INITREMOTE"))
         self.remote.initremote.call_count == 1
@@ -363,7 +363,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
         self.remote.error.assert_called_once_with("ErrorMsg")
 
 
-class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
+class TestGitAnnexRequestMessagesExporttree(utils.ExportTestCase):
     def test_ExportsupportedSuccess(self):
         self.annex.Listen(io.StringIO("EXPORTSUPPORTED"))
         self.remote.exportsupported.call_count == 1
@@ -680,7 +680,7 @@ class LoggingRemote(utils.MinimalRemote):
         self.logger.warning("test\nthis is a new line")
 
 
-class TestLogging(utils.GitAnnexTestCase):
+class TestLogging(utils.ExportTestCase):
     def setUp(self):
         super().setUp()
         self.remote = LoggingRemote(self.annex)

--- a/tests/test_SpecialRemoteMessages.py
+++ b/tests/test_SpecialRemoteMessages.py
@@ -4,7 +4,13 @@ import utils
 ProtocolError = utils.annexremote.ProtocolError
 
 
-class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
+class TestProtocolVersion2(utils.ExportTestCase):
+    def TestVersion(self):
+        self.annex.Listen(self.input)
+        self.assertEqual(self.output.getvalue(), "VERSION 2\n")
+
+
+class TestSpecialRemoteMessages(utils.FullTestCase):
     """
     * Each protocol line starts with a command, which is followed by the command's parameters
     (a fixed number per command), each separated by a single space.
@@ -451,7 +457,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
         self._perform_test(function_to_call, function_parameters, expected_output)
 
 
-class TestSpecialRemoteMessages_Extensions(utils.GitAnnexTestCase):
+class TestSpecialRemoteMessages_Extensions(utils.FullTestCase):
     def _perform_test(
         self,
         function_to_call,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,19 +9,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import annexremote
 
 
-class GitAnnexTestCase(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.output = io.StringIO()
-        self.input = io.StringIO()
-
-        self.annex = annexremote.Master(self.output)
-        self.remote = mock.MagicMock(wraps=DummyRemote(self.annex))
-
-        self.annex.LinkRemote(self.remote)
-
-
 class MinimalTestCase(unittest.TestCase):
     def setUp(self):
         super().setUp()
@@ -31,6 +18,32 @@ class MinimalTestCase(unittest.TestCase):
 
         self.annex = annexremote.Master(self.output)
         self.remote = MinimalRemote(self.annex)
+
+        self.annex.LinkRemote(self.remote)
+
+
+class FullTestCase(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.output = io.StringIO()
+        self.input = io.StringIO()
+
+        self.annex = annexremote.Master(self.output)
+        self.remote = mock.MagicMock(wraps=FullRemote(self.annex))
+
+        self.annex.LinkRemote(self.remote)
+
+
+class ExportTestCase(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.output = io.StringIO()
+        self.input = io.StringIO()
+
+        self.annex = annexremote.Master(self.output)
+        self.remote = mock.MagicMock(wraps=FullExportRemote(self.annex))
 
         self.annex.LinkRemote(self.remote)
 
@@ -77,7 +90,45 @@ class MinimalRemote(annexremote.SpecialRemote):
         pass
 
 
-class DummyRemote(annexremote.ExportRemote):
+class FullRemote(annexremote.SpecialRemote):
+    def initremote(self):
+        pass
+
+    def prepare(self):
+        pass
+
+    def transfer_store(self, key, file_):
+        pass
+
+    def transfer_retrieve(self, key, file_):
+        pass
+
+    def checkpresent(self, key):
+        pass
+
+    def remove(self, key):
+        pass
+
+    def getcost(self):
+        pass
+
+    def getavailability(self):
+        pass
+
+    def claimurl(self, url):
+        pass
+
+    def checkurl(self, url):
+        pass
+
+    def whereis(self, whereis):
+        pass
+
+    def error(self, msg):
+        pass
+
+
+class FullExportRemote(annexremote.ExportRemote):
     def initremote(self):
         pass
 


### PR DESCRIPTION
git-annex has a bug[1] that affects special remotes that support exporttree: Sometimes the EXPORT command is sent to a different process of the external remote than the following TRANSFEREXPORT command and as a result, one process receives two EXPORTs in a row.

This PR adds a check of consecutive EXPORTs so that the remote replies with an ERROR in this case.

Versions of git-annex that contain a fix now accept VERSION 2 from external special remotes.
Starting with this commit, AnnexRemote will send VERSION 2 if exporttree
is supported by the remote and VERSION 1 if not.

[1] http://git-annex.branchable.com/bugs/external_remote_export_sent_to_wrong_process