### PR TITLE
Switch from nose to pytest, add 3.12.0-rc3 into matrix 

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12.0-rc.3"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 nose3 coverage
+        python -m pip install flake8 pytest coverage
         pip install .
     - name: Lint with flake8
       run: |
@@ -35,7 +35,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with nosetests
+    - name: Test with pytest
       run: |
-        cd tests
-        nosetests
+        python -m pytest -s -v tests

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 build/*
 *.egg-info/*
 */_version.py
+.coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,9 @@ repos:
   - id: black
 - repo: local
   hooks:
-    - id: nosetests
-      name: nosetests
-      entry: nosetests
+    - id: pytest
+      name: pytest
+      entry: pytest -s -v
       language: system
       always_run: true
       pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You need python3 installed on your system.
 
 ### Running the tests
 If you want to run the tests, copy the content of the `tests` folder to the same location as `annexremote.py`.
-Then use a test discovery like [nose](http://nose.readthedocs.io) to run them.
+Then use a test discovery like [pytest](https://github.com/pytest-dev/pytest) to run them.
 
 ### Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ Documentation = "https://lykos153.github.io/AnnexRemote"
 Source = "https://github.com/Lykos153/AnnexRemote"
 
 [project.optional-dependencies]
-tests = ['coverage', 'nose']
+tests = ['coverage', 'pytest']
 doc = ["sphinx"]
 
 [build-system]

--- a/tests/test_AnnexRemoteSetup.py
+++ b/tests/test_AnnexRemoteSetup.py
@@ -13,7 +13,7 @@ class SetupTestCase(unittest.TestCase):
         self.output = io.StringIO()
         self.input = io.StringIO()
 
-    def TestListenNotLinked(self):
+    def test_ListenNotLinked(self):
         annex = annexremote.Master(self.output)
         with self.assertRaises(annexremote.NotLinkedError):
             annex.Listen(io.StringIO("INITREMOTE"))

--- a/tests/test_GitAnnexRequestMessages.py
+++ b/tests/test_GitAnnexRequestMessages.py
@@ -11,12 +11,12 @@ UnsupportedReqeust = utils.annexremote.UnsupportedRequest
 
 
 class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
-    def TestInitremoteSuccess(self):
+    def test_InitremoteSuccess(self):
         self.annex.Listen(io.StringIO("INITREMOTE"))
         self.remote.initremote.call_count == 1
         self.assertEqual(utils.second_buffer_line(self.output), "INITREMOTE-SUCCESS")
 
-    def TestInitremoteFailure(self):
+    def test_InitremoteFailure(self):
         self.remote.initremote.side_effect = RemoteError("ErrorMsg")
         self.annex.Listen(io.StringIO("INITREMOTE"))
         self.remote.initremote.call_count == 1
@@ -24,16 +24,16 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "INITREMOTE-FAILURE ErrorMsg"
         )
 
-    def TestExtensions(self):
+    def test_Extensions(self):
         self.annex.Listen(io.StringIO("EXTENSIONS Annex1 Annex2"))
         self.assertEqual(utils.second_buffer_line(self.output), "EXTENSIONS")
 
-    def TestPrepareSuccess(self):
+    def test_PrepareSuccess(self):
         self.annex.Listen(io.StringIO("PREPARE"))
         self.remote.prepare.call_count == 1
         self.assertEqual(utils.second_buffer_line(self.output), "PREPARE-SUCCESS")
 
-    def TestPrepareFailure(self):
+    def test_PrepareFailure(self):
         self.remote.prepare.side_effect = RemoteError("ErrorMsg")
         self.annex.Listen(io.StringIO("PREPARE"))
         self.remote.prepare.call_count == 1
@@ -41,14 +41,14 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "PREPARE-FAILURE ErrorMsg"
         )
 
-    def TestTransferStoreSuccess(self):
+    def test_TransferStoreSuccess(self):
         self.annex.Listen(io.StringIO("TRANSFER STORE Key File"))
         self.remote.transfer_store.assert_called_once_with("Key", "File")
         self.assertEqual(
             utils.second_buffer_line(self.output), "TRANSFER-SUCCESS STORE Key"
         )
 
-    def TestTransferStoreFailure(self):
+    def test_TransferStoreFailure(self):
         self.remote.transfer_store.side_effect = RemoteError("ErrorMsg")
         self.annex.Listen(io.StringIO("TRANSFER STORE Key File"))
         self.remote.transfer_store.assert_called_once_with("Key", "File")
@@ -56,23 +56,23 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "TRANSFER-FAILURE STORE Key ErrorMsg"
         )
 
-    def TestTransferStoreMissingFilename(self):
+    def test_TransferStoreMissingFilename(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("TRANSFER STORE Key"))
         self.assertEqual(utils.last_buffer_line(self.output), "ERROR Expected Key File")
 
-    def TestTransferStore_SpaceInFilename(self):
+    def test_TransferStore_SpaceInFilename(self):
         self.annex.Listen(io.StringIO("TRANSFER STORE Key File with spaces"))
         self.remote.transfer_store.assert_called_once_with("Key", "File with spaces")
 
-    def TestTransferRetrieveSuccess(self):
+    def test_TransferRetrieveSuccess(self):
         self.annex.Listen(io.StringIO("TRANSFER RETRIEVE Key File"))
         self.remote.transfer_retrieve.assert_called_once_with("Key", "File")
         self.assertEqual(
             utils.second_buffer_line(self.output), "TRANSFER-SUCCESS RETRIEVE Key"
         )
 
-    def TestTransferRetrieveFailure(self):
+    def test_TransferRetrieveFailure(self):
         self.remote.transfer_retrieve.side_effect = RemoteError("ErrorMsg")
         self.annex.Listen(io.StringIO("TRANSFER RETRIEVE Key File"))
         self.remote.transfer_retrieve.assert_called_once_with("Key", "File")
@@ -81,16 +81,16 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             "TRANSFER-FAILURE RETRIEVE Key ErrorMsg",
         )
 
-    def TestTransferRetrieve_MissingFilename(self):
+    def test_TransferRetrieve_MissingFilename(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("TRANSFER RETRIEVE Key"))
         self.assertEqual(utils.last_buffer_line(self.output), "ERROR Expected Key File")
 
-    def TestTransferRetrieve_SpaceInFilename(self):
+    def test_TransferRetrieve_SpaceInFilename(self):
         self.annex.Listen(io.StringIO("TRANSFER RETRIEVE Key File with spaces"))
         self.remote.transfer_retrieve.assert_called_once_with("Key", "File with spaces")
 
-    def TestCheckpresentSuccess(self):
+    def test_CheckpresentSuccess(self):
         self.remote.checkpresent.return_value = True
         self.annex.Listen(io.StringIO("CHECKPRESENT Key"))
         self.remote.checkpresent.assert_called_once_with("Key")
@@ -98,7 +98,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "CHECKPRESENT-SUCCESS Key"
         )
 
-    def TestCheckpresentFailure(self):
+    def test_CheckpresentFailure(self):
         self.remote.checkpresent.return_value = False
         self.annex.Listen(io.StringIO("CHECKPRESENT Key"))
         self.remote.checkpresent.assert_called_once_with("Key")
@@ -106,7 +106,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "CHECKPRESENT-FAILURE Key"
         )
 
-    def TestCheckpresentUnknown(self):
+    def test_CheckpresentUnknown(self):
         self.remote.checkpresent.side_effect = RemoteError("ErrorMsg")
         self.annex.Listen(io.StringIO("CHECKPRESENT Key"))
         self.remote.checkpresent.assert_called_once_with("Key")
@@ -114,12 +114,12 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "CHECKPRESENT-UNKNOWN Key ErrorMsg"
         )
 
-    def TestRemoveSuccess(self):
+    def test_RemoveSuccess(self):
         self.annex.Listen(io.StringIO("REMOVE Key"))
         self.remote.remove.assert_called_once_with("Key")
         self.assertEqual(utils.second_buffer_line(self.output), "REMOVE-SUCCESS Key")
 
-    def TestRemoveFailure(self):
+    def test_RemoveFailure(self):
         self.remote.remove.side_effect = RemoteError("ErrorMsg")
         self.annex.Listen(io.StringIO("REMOVE Key"))
         self.remote.remove.assert_called_once_with("Key")
@@ -127,7 +127,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "REMOVE-FAILURE Key ErrorMsg"
         )
 
-    def TestListconfigs(self):
+    def test_Listconfigs(self):
         self.remote.listconfigs.return_value = {
             "Name": "Description",
             "con1": "necessary configuration",
@@ -145,7 +145,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             ],
         )
 
-    def TestListconfigsSpaceInName(self):
+    def test_ListconfigsSpaceInName(self):
         self.remote.listconfigs.return_value = {"Name with space": "Description"}
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("LISTCONFIGS"))
@@ -154,13 +154,13 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             "ERROR Name must not contain space characters: Name with space",
         )
 
-    def TestGetcost(self):
+    def test_Getcost(self):
         self.remote.getcost.return_value = 5
         self.annex.Listen(io.StringIO("GETCOST"))
         self.remote.getcost.call_count == 1
         self.assertEqual(utils.second_buffer_line(self.output), "COST 5")
 
-    def TestGetcostInvalid(self):
+    def test_GetcostInvalid(self):
         self.remote.getcost.return_value = "not a number"
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("GETCOST"))
@@ -168,19 +168,19 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.last_buffer_line(self.output), "ERROR Cost must be an integer"
         )
 
-    def TestGetavailabilityGlobal(self):
+    def test_GetavailabilityGlobal(self):
         self.remote.getavailability.return_value = "global"
         self.annex.Listen(io.StringIO("GETAVAILABILITY"))
         self.remote.getavailability.call_count == 1
         self.assertEqual(utils.second_buffer_line(self.output), "AVAILABILITY GLOBAL")
 
-    def TestGetavailabilityLocal(self):
+    def test_GetavailabilityLocal(self):
         self.remote.getavailability.return_value = "local"
         self.annex.Listen(io.StringIO("GETAVAILABILITY"))
         self.remote.getavailability.call_count == 1
         self.assertEqual(utils.second_buffer_line(self.output), "AVAILABILITY LOCAL")
 
-    def TestGetavailabilityInvalid(self):
+    def test_GetavailabilityInvalid(self):
         self.remote.getavailability.return_value = "something else"
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("GETAVAILABILITY"))
@@ -189,18 +189,18 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             "ERROR Availability must be either 'global' or 'local'",
         )
 
-    def TestClaimurlSuccess(self):
+    def test_ClaimurlSuccess(self):
         self.remote.claimurl.return_value = True
         self.annex.Listen(io.StringIO("CLAIMURL Url"))
         self.remote.claimurl.assert_called_once_with("Url")
         self.assertEqual(utils.second_buffer_line(self.output), "CLAIMURL-SUCCESS")
 
-    def TestClaimurlFailure(self):
+    def test_ClaimurlFailure(self):
         self.remote.claimurl.return_value = False
         self.annex.Listen(io.StringIO("CLAIMURL Url"))
         self.assertEqual(utils.second_buffer_line(self.output), "CLAIMURL-FAILURE")
 
-    def TestCheckurlContentsTrue(self):
+    def test_CheckurlContentsTrue(self):
         self.remote.checkurl.return_value = True
         self.annex.Listen(io.StringIO("CHECKURL Url"))
         self.remote.checkurl.assert_called_once_with("Url")
@@ -208,7 +208,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "CHECKURL-CONTENTS UNKNOWN"
         )
 
-    def TestCheckurlContents(self):
+    def test_CheckurlContents(self):
         self.remote.checkurl.return_value = [{"size": 512, "filename": "Filename"}]
         self.annex.Listen(io.StringIO("CHECKURL Url"))
         self.remote.checkurl.assert_called_once_with("Url")
@@ -216,7 +216,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "CHECKURL-CONTENTS 512 Filename"
         )
 
-    def TestCheckurlContentsUnknownSize(self):
+    def test_CheckurlContentsUnknownSize(self):
         self.remote.checkurl.return_value = [{"filename": "Filename"}]
         self.annex.Listen(io.StringIO("CHECKURL Url"))
         self.remote.checkurl.assert_called_once_with("Url")
@@ -224,13 +224,13 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "CHECKURL-CONTENTS UNKNOWN Filename"
         )
 
-    def TestCheckurlContentsWithoutFilename(self):
+    def test_CheckurlContentsWithoutFilename(self):
         self.remote.checkurl.return_value = [{"size": 512}]
         self.annex.Listen(io.StringIO("CHECKURL Url"))
         self.remote.checkurl.assert_called_once_with("Url")
         self.assertEqual(utils.second_buffer_line(self.output), "CHECKURL-CONTENTS 512")
 
-    def TestCheckurlContentsWithoutSizeAndFilename(self):
+    def test_CheckurlContentsWithoutSizeAndFilename(self):
         self.remote.checkurl.return_value = True
         self.annex.Listen(io.StringIO("CHECKURL Url"))
         self.remote.checkurl.assert_called_once_with("Url")
@@ -238,7 +238,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "CHECKURL-CONTENTS UNKNOWN"
         )
 
-    def TestCheckurlMultiOneItemWithUrl(self):
+    def test_CheckurlMultiOneItemWithUrl(self):
         self.remote.checkurl.return_value = [
             {"url": "Url_exact", "size": 512, "filename": "Filename"}
         ]
@@ -249,7 +249,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             "CHECKURL-MULTI Url_exact 512 Filename",
         )
 
-    def TestCheckurlMultiTwoUrls(self):
+    def test_CheckurlMultiTwoUrls(self):
         urllist = [
             {"url": "Url1", "size": 512, "filename": "Filename1"},
             {"url": "Url2", "filename": "Filename2"},
@@ -262,7 +262,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             "CHECKURL-MULTI Url1 512 Filename1 Url2 UNKNOWN Filename2",
         )
 
-    def TestCheckurlMultiFiveUrls(self):
+    def test_CheckurlMultiFiveUrls(self):
         urllist = [
             {"url": "Url1", "size": 512, "filename": "Filename1"},
             {"url": "Url2", "filename": "Filename2"},
@@ -278,7 +278,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             "CHECKURL-MULTI Url1 512 Filename1 Url2 UNKNOWN Filename2 Url3 1024  Url4 134789 Filename4 Url5 UNKNOWN Filename5",
         )
 
-    def TestCheckurlMultiSpaceInUrl(self):
+    def test_CheckurlMultiSpaceInUrl(self):
         urllist = [
             {"url": "Url with spaces", "size": 512, "filename": "Filename1"},
             {"url": "Url2", "filename": "Filename2"},
@@ -290,7 +290,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.last_buffer_line(self.output), "ERROR Url must not contain spaces."
         )
 
-    def TestCheckurlMultiSpaceInFilename(self):
+    def test_CheckurlMultiSpaceInFilename(self):
         urllist = [
             {"url": "Url1", "size": 512, "filename": "Filename with spaces"},
             {"url": "Url2", "filename": "Filename2"},
@@ -303,7 +303,7 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             "ERROR Filename must not contain spaces.",
         )
 
-    def TestCheckurlMultiTabInUrlAndFilename(self):
+    def test_CheckurlMultiTabInUrlAndFilename(self):
         urllist = [
             {"url": "Url\twith\ttabs", "size": 512, "filename": "Filename1"},
             {"url": "Url2", "filename": "Filename\twith\ttabs"},
@@ -313,19 +313,19 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
         result = "CHECKURL-MULTI Url\twith\ttabs 512 Filename1 Url2 UNKNOWN Filename\twith\ttabs"
         self.assertEqual(utils.second_buffer_line(self.output), result)
 
-    def TestCheckurlFailure(self):
+    def test_CheckurlFailure(self):
         self.remote.checkurl.side_effect = RemoteError()
         self.annex.Listen(io.StringIO("CHECKURL Url"))
         self.remote.checkurl.assert_called_once_with("Url")
         self.assertEqual(utils.second_buffer_line(self.output), "CHECKURL-FAILURE")
 
-    def TestCheckurlFailureByException(self):
+    def test_CheckurlFailureByException(self):
         self.remote.checkurl.return_value = False
         self.annex.Listen(io.StringIO("CHECKURL Url"))
         self.remote.checkurl.assert_called_once_with("Url")
         self.assertEqual(utils.second_buffer_line(self.output), "CHECKURL-FAILURE")
 
-    def TestWhereisSuccess(self):
+    def test_WhereisSuccess(self):
         self.remote.whereis.return_value = "String"
         self.annex.Listen(io.StringIO("WHEREIS Key"))
         self.remote.whereis.assert_called_once_with("Key")
@@ -333,13 +333,13 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "WHEREIS-SUCCESS String"
         )
 
-    def TestWhereisFailure(self):
+    def test_WhereisFailure(self):
         self.remote.whereis.return_value = False
         self.annex.Listen(io.StringIO("WHEREIS Key"))
         self.remote.whereis.assert_called_once_with("Key")
         self.assertEqual(utils.second_buffer_line(self.output), "WHEREIS-FAILURE")
 
-    def TestGetinfo(self):
+    def test_Getinfo(self):
         self.remote.info = {"info field 1": "infovalue", "info field 2": "infovalue 2"}
         self.annex.Listen(io.StringIO("GETINFO"))
         self.assertEqual(
@@ -353,25 +353,25 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
             ],
         )
 
-    def TestGetinfoNone(self):
+    def test_GetinfoNone(self):
         self.remote.info = {}
         self.annex.Listen(io.StringIO("GETINFO"))
         self.assertEqual(utils.buffer_lines(self.output)[1:], ["INFOEND"])
 
-    def TestError(self):
+    def test_Error(self):
         self.annex.Listen(io.StringIO("ERROR ErrorMsg"))
         self.remote.error.assert_called_once_with("ErrorMsg")
 
 
 class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
-    def TestExportsupportedSuccess(self):
+    def test_ExportsupportedSuccess(self):
         self.annex.Listen(io.StringIO("EXPORTSUPPORTED"))
         self.remote.exportsupported.call_count == 1
         self.assertEqual(
             utils.second_buffer_line(self.output), "EXPORTSUPPORTED-SUCCESS"
         )
 
-    def TestExportsupportedFailure(self):
+    def test_ExportsupportedFailure(self):
         self.remote.exportsupported.return_value = False
         self.annex.Listen(io.StringIO("EXPORTSUPPORTED"))
         self.remote.exportsupported.call_count == 1
@@ -379,7 +379,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "EXPORTSUPPORTED-FAILURE"
         )
 
-    def TestExport_MissingName(self):
+    def test_Export_MissingName(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("EXPORT"))
         self.assertRegex(
@@ -387,7 +387,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             r"ERROR (Protocol\.|)do_EXPORT\(\) missing 1 required positional argument: 'name'",
         )
 
-    def TestExport_SpaceInName(self):
+    def test_Export_SpaceInName(self):
         # testing this only with TRANSFEREXPORT
         self.annex.Listen(
             io.StringIO("EXPORT Name with spaces\nTRANSFEREXPORT STORE Key File")
@@ -396,14 +396,14 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             "Key", "File", "Name with spaces"
         )
 
-    def TestTransferexportStoreSuccess(self):
+    def test_TransferexportStoreSuccess(self):
         self.annex.Listen(io.StringIO("EXPORT Name\nTRANSFEREXPORT STORE Key File"))
         self.remote.transferexport_store.assert_called_once_with("Key", "File", "Name")
         self.assertEqual(
             utils.second_buffer_line(self.output), "TRANSFER-SUCCESS STORE Key"
         )
 
-    def TestTransferexportStoreFailure(self):
+    def test_TransferexportStoreFailure(self):
         self.remote.transferexport_store.side_effect = RemoteError("ErrorMsg")
         self.annex.Listen(io.StringIO("EXPORT Name\nTRANSFEREXPORT STORE Key File"))
         self.remote.transferexport_store.assert_called_once_with("Key", "File", "Name")
@@ -411,7 +411,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "TRANSFER-FAILURE STORE Key ErrorMsg"
         )
 
-    def TestTransferexportStore_WithoutExport(self):
+    def test_TransferexportStore_WithoutExport(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("TRANSFEREXPORT STORE Key"))
         self.assertEqual(
@@ -419,12 +419,12 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             "ERROR Export request without prior EXPORT",
         )
 
-    def TestTransferexportStore_MissingFilename(self):
+    def test_TransferexportStore_MissingFilename(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("EXPORT Name\nTRANSFEREXPORT STORE Key"))
         self.assertEqual(utils.last_buffer_line(self.output), "ERROR Expected Key File")
 
-    def TestTransferexportStore_SpaceInFilename(self):
+    def test_TransferexportStore_SpaceInFilename(self):
         self.annex.Listen(
             io.StringIO("EXPORT Name\nTRANSFEREXPORT STORE Key File with spaces")
         )
@@ -432,7 +432,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             "Key", "File with spaces", "Name"
         )
 
-    def TestTransferexportStore_SpecialCharacterInName(self):
+    def test_TransferexportStore_SpecialCharacterInName(self):
         self.annex.Listen(
             io.StringIO("EXPORT Näme\nTRANSFEREXPORT STORE Key File with spaces")
         )
@@ -440,7 +440,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             "Key", "File with spaces", "Näme"
         )
 
-    def TestTransferexportStore_UnicodeCharacterInName(self):
+    def test_TransferexportStore_UnicodeCharacterInName(self):
         self.annex.Listen(
             io.StringIO("EXPORT Name 😀\nTRANSFEREXPORT STORE Key File with spaces")
         )
@@ -448,7 +448,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             "Key", "File with spaces", "Name 😀"
         )
 
-    def TestTransferexportRetrieveSuccess(self):
+    def test_TransferexportRetrieveSuccess(self):
         self.annex.Listen(io.StringIO("EXPORT Name\nTRANSFEREXPORT RETRIEVE Key File"))
         self.remote.transferexport_retrieve.assert_called_once_with(
             "Key", "File", "Name"
@@ -457,7 +457,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "TRANSFER-SUCCESS RETRIEVE Key"
         )
 
-    def TestTransferexportRetrieveFailure(self):
+    def test_TransferexportRetrieveFailure(self):
         self.remote.transferexport_retrieve.side_effect = RemoteError("ErrorMsg")
         self.annex.Listen(io.StringIO("EXPORT Name\nTRANSFEREXPORT RETRIEVE Key File"))
         self.remote.transferexport_retrieve.assert_called_once_with(
@@ -468,7 +468,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             "TRANSFER-FAILURE RETRIEVE Key ErrorMsg",
         )
 
-    def TestTransferexportRetrieve_WithoutExport(self):
+    def test_TransferexportRetrieve_WithoutExport(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("TRANSFEREXPORT RETRIEVE Key"))
         self.assertEqual(
@@ -476,12 +476,12 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             "ERROR Export request without prior EXPORT",
         )
 
-    def TestTransferexportRetrieve_MissingFilename(self):
+    def test_TransferexportRetrieve_MissingFilename(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("EXPORT Name\nTRANSFEREXPORT RETRIEVE Key"))
         self.assertEqual(utils.last_buffer_line(self.output), "ERROR Expected Key File")
 
-    def TestTransferexportRetrieve_SpaceInFilename(self):
+    def test_TransferexportRetrieve_SpaceInFilename(self):
         self.annex.Listen(
             io.StringIO("EXPORT Name\nTRANSFEREXPORT RETRIEVE Key File with spaces")
         )
@@ -489,7 +489,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             "Key", "File with spaces", "Name"
         )
 
-    def TestCheckpresentexportSuccess(self):
+    def test_CheckpresentexportSuccess(self):
         self.remote.checkpresentexport.return_value = True
         self.annex.Listen(io.StringIO("EXPORT Name\nCHECKPRESENTEXPORT Key"))
         self.remote.checkpresentexport.assert_called_once_with("Key", "Name")
@@ -497,7 +497,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "CHECKPRESENT-SUCCESS Key"
         )
 
-    def TestCheckpresentexportFailure(self):
+    def test_CheckpresentexportFailure(self):
         self.remote.checkpresentexport.return_value = False
         self.annex.Listen(io.StringIO("EXPORT Name\nCHECKPRESENTEXPORT Key"))
         self.remote.checkpresentexport.assert_called_once_with("Key", "Name")
@@ -505,7 +505,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "CHECKPRESENT-FAILURE Key"
         )
 
-    def TestCheckpresentexportUnknown(self):
+    def test_CheckpresentexportUnknown(self):
         self.remote.checkpresentexport.side_effect = RemoteError("ErrorMsg")
         self.annex.Listen(io.StringIO("EXPORT Name\nCHECKPRESENTEXPORT Key"))
         self.remote.checkpresentexport.assert_called_once_with("Key", "Name")
@@ -513,7 +513,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "CHECKPRESENT-UNKNOWN Key ErrorMsg"
         )
 
-    def TestCheckpresentexport_WithoutExport(self):
+    def test_Checkpresentexport_WithoutExport(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("CHECKPRESENTEXPORT Key"))
         self.assertEqual(
@@ -521,12 +521,12 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             "ERROR Export request without prior EXPORT",
         )
 
-    def TestRemoveexportSuccess(self):
+    def test_RemoveexportSuccess(self):
         self.annex.Listen(io.StringIO("EXPORT Name\nREMOVEEXPORT Key"))
         self.remote.removeexport.assert_called_once_with("Key", "Name")
         self.assertEqual(utils.second_buffer_line(self.output), "REMOVE-SUCCESS Key")
 
-    def TestRemoveexportFailure(self):
+    def test_RemoveexportFailure(self):
         self.remote.removeexport.side_effect = RemoteError("ErrorMsg")
         self.annex.Listen(io.StringIO("EXPORT Name\nREMOVEEXPORT Key"))
         self.remote.removeexport.assert_called_once_with("Key", "Name")
@@ -534,7 +534,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "REMOVE-FAILURE Key ErrorMsg"
         )
 
-    def TestRemoveexport_WithoutExport(self):
+    def test_Removeexport_WithoutExport(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("REMOVEEXPORT Key"))
         self.assertEqual(
@@ -542,14 +542,14 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             "ERROR Export request without prior EXPORT",
         )
 
-    def TestRemoveexportdirectorySuccess(self):
+    def test_RemoveexportdirectorySuccess(self):
         self.annex.Listen(io.StringIO("REMOVEEXPORTDIRECTORY Directory"))
         self.remote.removeexportdirectory.assert_called_once_with("Directory")
         self.assertEqual(
             utils.second_buffer_line(self.output), "REMOVEEXPORTDIRECTORY-SUCCESS"
         )
 
-    def TestRemoveexportdirectoryFailure(self):
+    def test_RemoveexportdirectoryFailure(self):
         self.remote.removeexportdirectory.side_effect = RemoteError()
         self.annex.Listen(io.StringIO("REMOVEEXPORTDIRECTORY Directory"))
         self.remote.removeexportdirectory.assert_called_once_with("Directory")
@@ -557,7 +557,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "REMOVEEXPORTDIRECTORY-FAILURE"
         )
 
-    def TestRemoveexportdirectory_MissingDirectory(self):
+    def test_Removeexportdirectory_MissingDirectory(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("REMOVEEXPORTDIRECTORY"))
         self.assertRegex(
@@ -565,20 +565,20 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             r"ERROR (Protocol\.|)do_REMOVEEXPORTDIRECTORY\(\) missing 1 required positional argument: 'name'",
         )
 
-    def TestRemoveexportdirectory_SpaceInFilename(self):
+    def test_Removeexportdirectory_SpaceInFilename(self):
         self.annex.Listen(io.StringIO("REMOVEEXPORTDIRECTORY Directory with spaces"))
         self.remote.removeexportdirectory.assert_called_once_with(
             "Directory with spaces"
         )
 
-    def TestRenameexportSuccess(self):
+    def test_RenameexportSuccess(self):
         self.annex.Listen(io.StringIO("EXPORT Name\nRENAMEEXPORT Key NewName"))
         self.remote.renameexport.assert_called_once_with("Key", "Name", "NewName")
         self.assertEqual(
             utils.second_buffer_line(self.output), "RENAMEEXPORT-SUCCESS Key"
         )
 
-    def TestRenameexportFailure(self):
+    def test_RenameexportFailure(self):
         self.remote.renameexport.side_effect = RemoteError()
         self.annex.Listen(io.StringIO("EXPORT Name\nRENAMEEXPORT Key NewName"))
         self.remote.renameexport.assert_called_once_with("Key", "Name", "NewName")
@@ -586,7 +586,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             utils.second_buffer_line(self.output), "RENAMEEXPORT-FAILURE Key"
         )
 
-    def TestRenameexport_WithoutExport(self):
+    def test_Renameexport_WithoutExport(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("RENAMEEXPORT Key NewName"))
         self.assertEqual(
@@ -594,7 +594,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             "ERROR Export request without prior EXPORT",
         )
 
-    def TestRenameexport_MissingNewName(self):
+    def test_Renameexport_MissingNewName(self):
         with self.assertRaises(SystemExit):
             self.annex.Listen(io.StringIO("EXPORT Name\nRENAMEEXPORT Key"))
         self.assertEqual(
@@ -602,7 +602,7 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
             "ERROR Expected TRANSFER STORE Key File",
         )
 
-    def TestRenameexport_SpaceInNewName(self):
+    def test_Renameexport_SpaceInNewName(self):
         self.annex.Listen(
             io.StringIO("EXPORT Name\nRENAMEEXPORT Key NewName with spaces")
         )
@@ -612,55 +612,55 @@ class TestGitAnnexRequestMessagesExporttree(utils.GitAnnexTestCase):
 
 
 class TestUnsupportedRequests(utils.MinimalTestCase):
-    def TestUnsupportedRequest(self):
+    def test_UnsupportedRequest(self):
         self.annex.Listen(io.StringIO("Not a request"))
         self.assertEqual(utils.second_buffer_line(self.output), "UNSUPPORTED-REQUEST")
 
-    def TestGetcostUnsupportedRequest(self):
+    def test_GetcostUnsupportedRequest(self):
         self.annex.Listen(io.StringIO("GETCOST"))
         self.assertEqual(utils.second_buffer_line(self.output), "UNSUPPORTED-REQUEST")
 
-    def TestGetavailabilityUnsupportedRequest(self):
+    def test_GetavailabilityUnsupportedRequest(self):
         self.annex.Listen(io.StringIO("GETAVAILABILITY"))
         self.assertEqual(utils.second_buffer_line(self.output), "UNSUPPORTED-REQUEST")
 
-    def TestClaimurlUnsupportedRequest(self):
+    def test_ClaimurlUnsupportedRequest(self):
         self.annex.Listen(io.StringIO("CLAIMURL Url"))
         self.assertEqual(utils.second_buffer_line(self.output), "UNSUPPORTED-REQUEST")
 
-    def TestCheckurlUnsupportedRequest(self):
+    def test_CheckurlUnsupportedRequest(self):
         self.annex.Listen(io.StringIO("CHECKURL Url"))
         self.assertEqual(utils.second_buffer_line(self.output), "UNSUPPORTED-REQUEST")
 
-    def TestWhereisUnsupportedRequest(self):
+    def test_WhereisUnsupportedRequest(self):
         self.annex.Listen(io.StringIO("WHEREIS Key"))
         self.assertEqual(utils.second_buffer_line(self.output), "UNSUPPORTED-REQUEST")
 
-    def TestTransferexportStoreUnsupportedRequest(self):
+    def test_TransferexportStoreUnsupportedRequest(self):
         self.annex.Listen(io.StringIO("EXPORT Name\nTRANSFEREXPORT STORE Key File"))
         self.assertEqual(utils.second_buffer_line(self.output), "UNSUPPORTED-REQUEST")
 
-    def TestTransferexportRetrieveUnsupportedRequest(self):
+    def test_TransferexportRetrieveUnsupportedRequest(self):
         self.annex.Listen(io.StringIO("EXPORT Name\nTRANSFEREXPORT RETRIEVE Key File"))
         self.assertEqual(utils.second_buffer_line(self.output), "UNSUPPORTED-REQUEST")
 
-    def TestCheckpresentexportUnsupportedRequest(self):
+    def test_CheckpresentexportUnsupportedRequest(self):
         self.annex.Listen(io.StringIO("EXPORT Name\nCHECKPRESENTEXPORT Key"))
         self.assertEqual(utils.second_buffer_line(self.output), "UNSUPPORTED-REQUEST")
 
-    def TestRemoveexportUnsupportedRequest(self):
+    def test_RemoveexportUnsupportedRequest(self):
         self.annex.Listen(io.StringIO("EXPORT Name\nREMOVEEXPORT Key"))
         self.assertEqual(utils.second_buffer_line(self.output), "UNSUPPORTED-REQUEST")
 
-    def TestRemoveexportdirectoryUnsupportedRequest(self):
+    def test_RemoveexportdirectoryUnsupportedRequest(self):
         self.annex.Listen(io.StringIO("REMOVEEXPORTDIRECTORY Directory"))
         self.assertEqual(utils.second_buffer_line(self.output), "UNSUPPORTED-REQUEST")
 
-    def TestRenameexportUnsupportedRequest(self):
+    def test_RenameexportUnsupportedRequest(self):
         self.annex.Listen(io.StringIO("EXPORT Name\nRENAMEEXPORT Key NewName"))
         self.assertEqual(utils.second_buffer_line(self.output), "UNSUPPORTED-REQUEST")
 
-    def TestListconfigsEmpty(self):
+    def test_ListconfigsEmpty(self):
         self.annex.Listen(io.StringIO("LISTCONFIGS"))
         self.assertEqual(utils.second_buffer_line(self.output), "CONFIGEND")
 
@@ -682,7 +682,7 @@ class TestLogging(utils.GitAnnexTestCase):
 
         self.annex.LinkRemote(self.remote)
 
-    def TestLogging(self):
+    def test_Logging(self):
         self.annex.Listen(io.StringIO("PREPARE"))
 
         buffer_lines = utils.buffer_lines(self.output)

--- a/tests/test_SpecialRemoteMessages.py
+++ b/tests/test_SpecialRemoteMessages.py
@@ -30,24 +30,24 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
                 utils.first_buffer_line(self.output).rstrip(), expected_output
             )
 
-    def TestVersion(self):
+    def test_Version(self):
         self.annex.Listen(self.input)
         self.assertEqual(self.output.getvalue(), "VERSION 1\n")
 
-    def TestProgress(self):
+    def test_Progress(self):
         function_to_call = self.annex.progress
         function_parameters = (2048,)
         expected_output = "PROGRESS 2048"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestProgressNotANumber(self):
+    def test_ProgressNotANumber(self):
         function_to_call = self.annex.progress
         function_parameters = ("NaN",)
         with self.assertRaises(ValueError):
             self._perform_test(function_to_call, function_parameters, "")
 
-    def TestDirhash(self):
+    def test_Dirhash(self):
         function_to_call = self.annex.dirhash
         function_parameters = ("Key",)
         expected_output = "DIRHASH Key"
@@ -62,7 +62,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestDirhashLower(self):
+    def test_DirhashLower(self):
         function_to_call = self.annex.dirhash_lower
         function_parameters = ("Key",)
         expected_output = "DIRHASH-LOWER Key"
@@ -77,14 +77,14 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestSetconfig(self):
+    def test_Setconfig(self):
         function_to_call = self.annex.setconfig
         function_parameters = ("Setting", "Value")
         expected_output = "SETCONFIG Setting Value"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestSetconfig_SpaceInValue(self):
+    def test_Setconfig_SpaceInValue(self):
         """
         The last parameter may contain spaces.
         """
@@ -94,7 +94,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestGetconfig(self):
+    def test_Getconfig(self):
         function_to_call = self.annex.getconfig
         function_parameters = ("Setting",)
         expected_output = "GETCONFIG Setting"
@@ -109,7 +109,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGetconfig_SpaceInValue(self):
+    def test_Getconfig_SpaceInValue(self):
         function_to_call = self.annex.getconfig
         function_parameters = ("Setting",)
         expected_output = "GETCONFIG Setting"
@@ -124,28 +124,28 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestSetcreds(self):
+    def test_Setcreds(self):
         function_to_call = self.annex.setcreds
         function_parameters = ("Setting", "User", "Password")
         expected_output = "SETCREDS Setting User Password"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestSetcreds_SpaceInPassword(self):
+    def test_Setcreds_SpaceInPassword(self):
         function_to_call = self.annex.setcreds
         function_parameters = ("Setting", "User", "Password with spaces")
         expected_output = "SETCREDS Setting User Password with spaces"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestSetcreds_NoPassword(self):
+    def test_Setcreds_NoPassword(self):
         function_to_call = self.annex.setcreds
         function_parameters = ("Setting", "User", "")
         expected_output = "SETCREDS Setting User"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestSetcreds_NoUser(self):
+    def test_Setcreds_NoUser(self):
         """
         Parameters may be empty, but the separating spaces are still required in that case.
         """
@@ -155,7 +155,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestGetcreds(self):
+    def test_Getcreds(self):
         function_to_call = self.annex.getcreds
         function_parameters = ("Setting",)
         expected_output = "GETCREDS Setting"
@@ -170,7 +170,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGetcreds_SpaceInPassword(self):
+    def test_Getcreds_SpaceInPassword(self):
         function_to_call = self.annex.getcreds
         function_parameters = ("Setting",)
         expected_output = "GETCREDS Setting"
@@ -185,7 +185,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGetcreds_NoPassword(self):
+    def test_Getcreds_NoPassword(self):
         function_to_call = self.annex.getcreds
         function_parameters = ("Setting",)
         expected_output = "GETCREDS Setting"
@@ -200,7 +200,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGetcreds_NoUser(self):
+    def test_Getcreds_NoUser(self):
         function_to_call = self.annex.getcreds
         function_parameters = ("Setting",)
         expected_output = "GETCREDS Setting"
@@ -215,7 +215,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGetuuid(self):
+    def test_Getuuid(self):
         function_to_call = self.annex.getuuid
         function_parameters = ()
         expected_output = "GETUUID"
@@ -230,7 +230,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGetgitdir(self):
+    def test_Getgitdir(self):
         function_to_call = self.annex.getgitdir
         function_parameters = ()
         expected_output = "GETGITDIR"
@@ -245,7 +245,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGetgitdir_SpaceInPath(self):
+    def test_Getgitdir_SpaceInPath(self):
         function_to_call = self.annex.getgitdir
         function_parameters = ()
         expected_output = "GETGITDIR"
@@ -260,14 +260,14 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestSetwanted(self):
+    def test_Setwanted(self):
         function_to_call = self.annex.setwanted
         function_parameters = ("Preferred Content Expression",)
         expected_output = "SETWANTED Preferred Content Expression"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestGetwanted(self):
+    def test_Getwanted(self):
         function_to_call = self.annex.getwanted
         function_parameters = ()
         expected_output = "GETWANTED"
@@ -282,28 +282,28 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestSetstate(self):
+    def test_Setstate(self):
         function_to_call = self.annex.setstate
         function_parameters = ("Key", "Value")
         expected_output = "SETSTATE Key Value"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestSetstate_SpaceInValue(self):
+    def test_Setstate_SpaceInValue(self):
         function_to_call = self.annex.setstate
         function_parameters = ("Key", "Value with spaces")
         expected_output = "SETSTATE Key Value with spaces"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestSetstate_NoValue(self):
+    def test_Setstate_NoValue(self):
         function_to_call = self.annex.setstate
         function_parameters = ("Key", "")
         expected_output = "SETSTATE Key"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestGetstate(self):
+    def test_Getstate(self):
         function_to_call = self.annex.getstate
         function_parameters = ("Key",)
         expected_output = "GETSTATE Key"
@@ -318,7 +318,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGetstate_SpaceInValue(self):
+    def test_Getstate_SpaceInValue(self):
         function_to_call = self.annex.getstate
         function_parameters = ("Key",)
         expected_output = "GETSTATE Key"
@@ -333,7 +333,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGetstate_NoValue(self):
+    def test_Getstate_NoValue(self):
         function_to_call = self.annex.getstate
         function_parameters = ("Key",)
         expected_output = "GETSTATE Key"
@@ -348,35 +348,35 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestSeturlpresent(self):
+    def test_Seturlpresent(self):
         function_to_call = self.annex.seturlpresent
         function_parameters = ("Key", "Url")
         expected_output = "SETURLPRESENT Key Url"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestSeturlmissing(self):
+    def test_Seturlmissing(self):
         function_to_call = self.annex.seturlmissing
         function_parameters = ("Key", "Url")
         expected_output = "SETURLMISSING Key Url"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestSeturipresent(self):
+    def test_Seturipresent(self):
         function_to_call = self.annex.seturipresent
         function_parameters = ("Key", "Uri")
         expected_output = "SETURIPRESENT Key Uri"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestSeturimissing(self):
+    def test_Seturimissing(self):
         function_to_call = self.annex.seturimissing
         function_parameters = ("Key", "Uri")
         expected_output = "SETURIMISSING Key Uri"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestGeturls_0(self):
+    def test_Geturls_0(self):
         function_to_call = self.annex.geturls
         function_parameters = ("Key", "Prefix")
         expected_output = "GETURLS Key Prefix"
@@ -391,7 +391,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGeturls_1(self):
+    def test_Geturls_1(self):
         function_to_call = self.annex.geturls
         function_parameters = ("Key", "Prefix")
         expected_output = "GETURLS Key Prefix"
@@ -406,7 +406,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGeturls_2(self):
+    def test_Geturls_2(self):
         function_to_call = self.annex.geturls
         function_parameters = ("Key", "Prefix")
         expected_output = "GETURLS Key Prefix"
@@ -421,7 +421,7 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGeturls_2_empty_prefix(self):
+    def test_Geturls_2_empty_prefix(self):
         function_to_call = self.annex.geturls
         function_parameters = ("Key", "")
         expected_output = "GETURLS Key"
@@ -436,14 +436,14 @@ class TestSpecialRemoteMessages(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestDebug(self):
+    def test_Debug(self):
         function_to_call = self.annex.debug
         function_parameters = ("message",)
         expected_output = "DEBUG message"
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestError(self):
+    def test_Error(self):
         function_to_call = self.annex.error
         function_parameters = ("ErrorMsg",)
         expected_output = "ERROR ErrorMsg"
@@ -467,7 +467,7 @@ class TestSpecialRemoteMessages_Extensions(utils.GitAnnexTestCase):
         self.assertEqual(utils.buffer_lines(self.output)[1].rstrip(), "EXTENSIONS")
         self.assertEqual(utils.buffer_lines(self.output)[2].rstrip(), expected_output)
 
-    def TestInfo(self):
+    def test_Info(self):
         self.annex.Listen(io.StringIO("EXTENSIONS INFO"))
         function_to_call = self.annex.info
         function_parameters = ("message",)
@@ -475,13 +475,13 @@ class TestSpecialRemoteMessages_Extensions(utils.GitAnnexTestCase):
 
         self._perform_test(function_to_call, function_parameters, expected_output)
 
-    def TestInfo_Unannounced(self):
+    def test_Info_Unannounced(self):
         function_to_call = self.annex.info
         function_parameters = ("message",)
         with self.assertRaises(ProtocolError):
             self._perform_test(function_to_call, function_parameters, "")
 
-    def TestGetgitremotename(self):
+    def test_Getgitremotename(self):
         self.annex.Listen(io.StringIO("EXTENSIONS GETGITREMOTENAME"))
         function_to_call = self.annex.getgitremotename
         function_parameters = ()
@@ -497,7 +497,7 @@ class TestSpecialRemoteMessages_Extensions(utils.GitAnnexTestCase):
             function_result,
         )
 
-    def TestGetgitremotename_Unannounced(self):
+    def test_Getgitremotename_Unannounced(self):
         function_to_call = self.annex.getgitremotename
         function_parameters = ()
         with self.assertRaises(ProtocolError):


### PR DESCRIPTION
- minimal changes to switch to pytest. Checked with `coverage run -m {nose,pytest}` invocations that coverage stays the same 98%
  - renamed all tests to start with test_ so that `pytest` could discover them 
- add 3.12 to github tests matrix (hopefully already supported)