### PR TITLE
Include v1.6.1 produced CHANGELOG (failed to push/finalize the release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,62 @@
+# v1.6.1 (Mon Sep 25 2023)
+
+#### 🐛 Bug Fix
+
+- Fix invalid escape sequences in test regexes [#76](https://github.com/Lykos153/AnnexRemote/pull/76) ([@musicinmybrain](https://github.com/musicinmybrain))
+- Add 3.10 and 3.11 into the mix of supported Pythons [#62](https://github.com/Lykos153/AnnexRemote/pull/62) ([@yarikoptic](https://github.com/yarikoptic))
+- Migrate from setup.py to pyproject.toml [#51](https://github.com/Lykos153/AnnexRemote/pull/51) ([@Lykos153](https://github.com/Lykos153))
+
+#### ⚠️ Pushed to `master`
+
+- Remove support for Python 3.6 (EOL) ([@Lykos153](https://github.com/Lykos153))
+
+#### 🏠 Internal
+
+- Use intuit auto for release [#73](https://github.com/Lykos153/AnnexRemote/pull/73) ([@yarikoptic](https://github.com/yarikoptic))
+- chore(deps): update actions/checkout action to v4 [#79](https://github.com/Lykos153/AnnexRemote/pull/79) ([@renovate[bot]](https://github.com/renovate[bot]))
+- chore(deps): update pre-commit hook psf/black to v23.9.1 [#77](https://github.com/Lykos153/AnnexRemote/pull/77) ([@renovate[bot]](https://github.com/renovate[bot]))
+- chore(deps): update codespell-project/actions-codespell action to v2 [#74](https://github.com/Lykos153/AnnexRemote/pull/74) ([@renovate[bot]](https://github.com/renovate[bot]))
+- chore(deps): update pre-commit hook psf/black to v23.3.0 [#70](https://github.com/Lykos153/AnnexRemote/pull/70) ([@renovate[bot]](https://github.com/renovate[bot]))
+- chore(deps): update pre-commit hook psf/black to v23 [#68](https://github.com/Lykos153/AnnexRemote/pull/68) ([@renovate[bot]](https://github.com/renovate[bot]))
+- chore(deps): update actions/checkout action to v3 [#58](https://github.com/Lykos153/AnnexRemote/pull/58) ([@renovate[bot]](https://github.com/renovate[bot]))
+- Add codespell CI, fix typos with 1 of its runs with -w [#63](https://github.com/Lykos153/AnnexRemote/pull/63) ([@yarikoptic](https://github.com/yarikoptic))
+- Update pre-commit hook psf/black to v22.8.0 [#57](https://github.com/Lykos153/AnnexRemote/pull/57) ([@renovate[bot]](https://github.com/renovate[bot]))
+- Update pre-commit hook psf/black to v22.6.0 [#56](https://github.com/Lykos153/AnnexRemote/pull/56) ([@renovate[bot]](https://github.com/renovate[bot]))
+- renovate: Add pre-commit [#55](https://github.com/Lykos153/AnnexRemote/pull/55) ([@Lykos153](https://github.com/Lykos153))
+- Update actions/setup-python action to v4 [#50](https://github.com/Lykos153/AnnexRemote/pull/50) ([@renovate[bot]](https://github.com/renovate[bot]))
+- Configure pre-commit for nosetests [#54](https://github.com/Lykos153/AnnexRemote/pull/54) ([@Lykos153](https://github.com/Lykos153))
+- Use black [#53](https://github.com/Lykos153/AnnexRemote/pull/53) ([@Lykos153](https://github.com/Lykos153))
+- Update Versioneer to 0.22 [#49](https://github.com/Lykos153/AnnexRemote/pull/49) ([@hugovk](https://github.com/hugovk) [@Lykos153](https://github.com/Lykos153))
+- Use versions instead of commit hashes for actions [#48](https://github.com/Lykos153/AnnexRemote/pull/48) ([@Lykos153](https://github.com/Lykos153))
+- Update actions/checkout action to v3 [#43](https://github.com/Lykos153/AnnexRemote/pull/43) ([@renovate-bot](https://github.com/renovate-bot))
+- Update actions/setup-python action to v3 [#44](https://github.com/Lykos153/AnnexRemote/pull/44) ([@renovate-bot](https://github.com/renovate-bot))
+- Update pypa/gh-action-pypi-publish digest to 717ba43 [#41](https://github.com/Lykos153/AnnexRemote/pull/41) ([@renovate-bot](https://github.com/renovate-bot))
+- Configure Renovate [#39](https://github.com/Lykos153/AnnexRemote/pull/39) ([@renovate-bot](https://github.com/renovate-bot) [@renovate[bot]](https://github.com/renovate[bot]))
+- Create action to publish on pypi [#35](https://github.com/Lykos153/AnnexRemote/pull/35) ([@Lykos153](https://github.com/Lykos153))
+
+#### 📝 Documentation
+
+- Remove bold claim that is not true anymore [#72](https://github.com/Lykos153/AnnexRemote/pull/72) ([@Lykos153](https://github.com/Lykos153))
+- Annotated code snippets in README as python for proper coloring etc [#64](https://github.com/Lykos153/AnnexRemote/pull/64) ([@yarikoptic](https://github.com/yarikoptic))
+- renovate: ignore docs/** [#47](https://github.com/Lykos153/AnnexRemote/pull/47) ([@Lykos153](https://github.com/Lykos153))
+- Add test and pypi badge to readme [#38](https://github.com/Lykos153/AnnexRemote/pull/38) ([@Lykos153](https://github.com/Lykos153))
+
+#### 🧪 Tests
+
+- Switch from nose to pytest, add 3.12.0-rc3 into matrix [#80](https://github.com/Lykos153/AnnexRemote/pull/80) ([@yarikoptic](https://github.com/yarikoptic))
+- Add github action for running nosetests [#37](https://github.com/Lykos153/AnnexRemote/pull/37) ([@Lykos153](https://github.com/Lykos153))
+
+#### Authors: 6
+
+- [@renovate[bot]](https://github.com/renovate[bot])
+- Ben Beasley ([@musicinmybrain](https://github.com/musicinmybrain))
+- Hugo van Kemenade ([@hugovk](https://github.com/hugovk))
+- Mend Renovate ([@renovate-bot](https://github.com/renovate-bot))
+- Silvio Ankermann ([@Lykos153](https://github.com/Lykos153))
+- Yaroslav Halchenko ([@yarikoptic](https://github.com/yarikoptic))
+
+---
+
 # 1.6.0 (2021-10-11)
 
 #### Added


### PR DESCRIPTION
Continuation of #73 which was to address #69.

As a release attempt upon merging #80 showed in https://github.com/Lykos153/AnnexRemote/actions/runs/6304559468/job/17116167502

```
ℹ  info      Tagging new tag: v1.6.0 => v1.6.1
ℹ  info      Calling after version hook
08aaf4c436a015a3a558da0c3d48d1483319ee1d	refs/heads/master
ℹ  info      Branch: master
ℹ  info      HEADs: 08aaf4c436a015a3a558da0c3d48d1483319ee1d	refs/heads/master
ℹ  info      Current branch is up to date, proceeding with release
ℹ  info      Calling publish hook
ℹ  info      Pushing new tag to GitHub
remote: error: GH006: Protected branch update failed for refs/heads/master.        
remote: error: Changes must be made through a pull request.        
To https://github.com/Lykos153/AnnexRemote
 * [new tag]         v1.6.1 -> v1.6.1
 ! [remote rejected] master -> master (protected branch hook declined)
error: failed to push some refs to 'https://github.com/Lykos153/AnnexRemote'
Error: Running command 'git' with args [push, --follow-tags, --set-upstream, https://****4owg@github.com/Lykos153/AnnexRemote, master] failed

remote: error: GH006: Protected branch update failed for refs/heads/master.        
remote: error: Changes must be made through a pull request.        
To https://github.com/Lykos153/AnnexRemote
 * [new tag]         v1.6.1 -> v1.6.1
 ! [remote rejected] master -> master (protected branch hook declined)
error: failed to push some refs to 'https://github.com/Lykos153/AnnexRemote'

  ...
```
so likely the `master` branch is protected and thus we can't push updated CHANGELOG to it :-/   

This PR includes that tag 1.6.1 changes (CHANGELOG) and after settings are fixed to permit pushing to master (ping @Lykos153 ) - we should merge and then 1.6.2 should be properly pushed/released.