### PR TITLE
Add actual twine upload call to .autorc to fix release to make it appear on PyPI

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -3,5 +3,13 @@
     "baseBranch": "master",
     "author": "auto <auto@nil>",
     "noVersionPrefix": false,
-    "plugins": ["git-tag", "released"]
+    "plugins": [
+        "git-tag",
+        [
+            "exec",
+            {
+                "afterRelease": "python -m build && twine upload dist/*"
+            }
+        ],
+        "released"]
 }


### PR DESCRIPTION
I think for this package I took workflow from dandi-cli but auto config from elsewhere.  In dandi-cli we awhile back moved running twine into auto configuration from github workflow. Now adding this here too