### PR TITLE
Revert "Add "workflow_dispatch:" as a way to trigger workflow"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-  workflow_dispatch:
 
 jobs:
   auto-release:


### PR DESCRIPTION
This reverts commit 0fde59ba280dc95ccdbd2d11b5090b48f646a4c7.

I have tried it as a possible means to trigger release without PR -- seems didn't do it, so I will revert and try to release with this.

Sorry for all the noise but I feel we are close ;)