### PR TITLE
Fix build - remove setuptools-git-versioning from pyproject.toml and also versioneer.py from MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-include versioneer.py
 include annexremote/_version.py
 include tests/*.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ doc = ["sphinx"]
 
 [build-system]
 requires = [
-    "setuptools>=64",
+    "setuptools>=41",
     "wheel",
-    "setuptools_scm>=8",
+    "setuptools_scm[toml]>=6.2",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,15 +33,11 @@ doc = ["sphinx"]
 
 [build-system]
 requires = [
-    "setuptools>=41",
+    "setuptools>=64",
     "wheel",
-    "setuptools-git-versioning",
-    "setuptools_scm[toml]>=6.2",
+    "setuptools_scm>=8",
 ]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools-git-versioning]
-enabled = true
 
 [tool.setuptools_scm]
 write_to = "annexremote/_version.py"


### PR DESCRIPTION
See individual commits.

Closes #93 - IMHO the main problem was having both setuptools-git-versioning and setuptools_scm which are for the same purpose, thus likely interfered.
I did some testing on my own repo in this branch for a while to arrive to this conclusion. e.g [sample log](https://github.com/yarikoptic/AnnexRemote/actions/runs/6673405277/job/18138925456)