### PR TITLE
Add listconfigs to examples/git-annex-remote-directory + a test for that

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -38,6 +38,10 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest -s -v --cov=annexremote --cov-report=xml tests
+    - name: Install git-annex needed for the next step
+      run: |
+        sudo apt update
+        sudo apt install -y git-annex
     - name: Test example external remote
       run: |
         examples/test_git-annex-remote-directory

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -38,6 +38,9 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest -s -v --cov=annexremote --cov-report=xml tests
+    - name: Test example external remote
+      run: |
+        examples/test_git-annex-remote-directory
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/examples/git-annex-remote-directory
+++ b/examples/git-annex-remote-directory
@@ -23,6 +23,9 @@ class DirectoryRemote(ExportRemote):
             raise RemoteError("You need to set directory=")
         self._mkdir(self.directory)
 
+    def listconfigs(self):
+        return {"directory": "directory where data is stored"}
+
     def prepare(self):
         self.directory = self.annex.getconfig("directory")
         self.info = {"directory": self.directory}

--- a/examples/test_git-annex-remote-directory
+++ b/examples/test_git-annex-remote-directory
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Test script to drive the example external remote
+
+set -eu -o pipefail -x
+
+cd $(dirname "$0")
+
+export PATH=$PWD:$PATH
+
+git-annex-remote-directory < /dev/null | grep VERSION
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/gar-XXXXXXX")"
+# so there is no global git config side-effects
+export HOME="$TMP"
+
+REMOTE_DIR="$TMP/remote"
+REPO_DIR="$TMP/repo"
+mkdir -p "$REMOTE_DIR"
+mkdir -p "$REPO_DIR"
+
+cd "$REPO_DIR"
+git init
+git config user.email "someuser@gmail.com"
+git config user.name "Some User"
+git annex init
+git annex initremote --verbose --debug directory_remote type=external externaltype=directory encryption=none directory=$REMOTE_DIR
+git annex testremote --verbose --debug directory_remote  2>&1 | tail -n 1000


### PR DESCRIPTION
This all is thanks to @notestaff who had it in conda-forge feedstock of the package https://github.com/conda-forge/annexremote-feedstock/pull/50 .

Now I am moving it here with some minor tune ups : made test script a little more generic/runnable without assumption of location , HOME, etc. and added it to be invoked in CI here.