### PR TITLE
Allow to communicate ErrorMsg for CHECKURL-FAILURE via RemoteError exception

### DIFF
--- a/annexremote/annexremote.py
+++ b/annexremote/annexremote.py
@@ -675,8 +675,8 @@ class Protocol(object):
     def do_CHECKURL(self, url):
         try:
             reply = self.remote.checkurl(url)
-        except RemoteError:
-            return "CHECKURL-FAILURE"
+        except RemoteError as e:
+            return "CHECKURL-FAILURE {e}".format(e=e).rstrip()
         if not reply:
             return "CHECKURL-FAILURE"
         elif reply is True:

--- a/tests/test_GitAnnexRequestMessages.py
+++ b/tests/test_GitAnnexRequestMessages.py
@@ -319,6 +319,14 @@ class TestGitAnnexRequestMessages(utils.GitAnnexTestCase):
         self.remote.checkurl.assert_called_once_with("Url")
         self.assertEqual(utils.second_buffer_line(self.output), "CHECKURL-FAILURE")
 
+    def test_CheckurlFailureErrorMsg(self):
+        self.remote.checkurl.side_effect = RemoteError("ErrorMsg")
+        self.annex.Listen(io.StringIO("CHECKURL Url"))
+        self.remote.checkurl.assert_called_once_with("Url")
+        self.assertEqual(
+            utils.second_buffer_line(self.output), "CHECKURL-FAILURE ErrorMsg"
+        )
+
     def test_CheckurlFailureByException(self):
         self.remote.checkurl.return_value = False
         self.annex.Listen(io.StringIO("CHECKURL Url"))


### PR DESCRIPTION
Similar pattern already used in various other locations but not for this check.  I used .rstrip() to guarantee no dangling whitespaces (which would break the existing test).

https://git-annex.branchable.com/design/external_special_remote_protocol/ says that

    CHECKURL-FAILURE ErrorMsg
        Indicates that the requested url could not be accessed.

so ErrorMsg is entirely legit.