### PR TITLE
Add macOS and Windows CI testing

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,11 +12,17 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - os: macos-latest
+            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.9"
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v6
@@ -40,9 +46,9 @@ jobs:
         python -m pytest -s -v --cov=annexremote --cov-report=xml tests
     - name: Install git-annex needed for the next step
       run: |
-        sudo apt update
-        sudo apt install -y git-annex
+        pip install git-annex
     - name: Test example external remote
+      if: runner.os != 'Windows'
       run: |
         examples/test_git-annex-remote-directory
     - name: Upload coverage to Codecov


### PR DESCRIPTION
Extend the test matrix to include macOS and Windows platforms with Python 3.9, while keeping all Python versions on Ubuntu. Use pip to install git-annex cross-platform instead of apt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

I have not realized that we do not test across OSes thus potentially creating an issue for usage within datalad. Also related is
- https://github.com/conda-forge/annexremote-feedstock/pull/57 by @matrss

TODOs:
- [ ] make work under Windows? I forgot how the special remotes execution etc is concocted under windows, so we might need tune for testing there.